### PR TITLE
Tweets fun facts for highlighted albums

### DIFF
--- a/app/models/scheduled_tweet.rb
+++ b/app/models/scheduled_tweet.rb
@@ -6,6 +6,7 @@ class ScheduledTweet < ActiveRecord::Base
   scope :songs, -> { where(type: 'TopSong') }
   scope :lyrics, -> { where(type: 'TopLyrics') }
   scope :albums, -> { where(type: 'AlbumAnniversary') }
+  scope :fun_facts, -> { where(type: 'FunFacts') }
   scope :during_dates, -> (date_range) do
     end_date = date_range.last + 23.hours + 59.minutes + 59.seconds
     where(scheduled_at: date_range.first..end_date)

--- a/app/views/admin/albums/index.html.erb
+++ b/app/views/admin/albums/index.html.erb
@@ -21,7 +21,7 @@
             <button ng-click="clearFunFact(album)">Clear</button>
           </div>
           <div ng-show="album.isEditing">
-            <textarea ng-model="album.fun_fact_description" placeholder="Fun fact about album…"></textarea>
+            <textarea ng-model="album.fun_fact_description" maxlength="100" placeholder="Fun fact about album…"></textarea>
             <input ng-model="album.fun_fact_source" placeholder="Source" />
             <button ng-click="updateFunFact(album)">Save</button>
             <button ng-click="cancelFunFactEdit(album)">Cancel</button>

--- a/lib/services/fun_facts/fun_fact_tweeter.rb
+++ b/lib/services/fun_facts/fun_fact_tweeter.rb
@@ -1,0 +1,33 @@
+module FunFacts
+  # Tweets fun facts about albums
+  class FunFactTweeter
+    def self.tweet_about(album)
+      new(album: album).tweet
+    end
+
+    def initialize(album:,
+                   twitter_client: WistfulIndie::Twitter::Client.client)
+      raise ArgumentError, 'Must pass an album' if album.nil?
+
+      @client = twitter_client
+      @album = album
+    end
+
+    def tweet
+      return unless fun_fact?
+      puts "Tweeting fun fact for #{album.artist.name} - #{album.name}"
+      @client.update(tweet_text)
+    end
+
+    private
+    attr_reader :album
+
+    def fun_fact?
+      !!album.fun_fact
+    end
+
+    def tweet_text
+      album.generated_fun_fact_description
+    end
+  end
+end

--- a/lib/services/tweet_schedule/fun_facts_scheduled_tweeter.rb
+++ b/lib/services/tweet_schedule/fun_facts_scheduled_tweeter.rb
@@ -1,0 +1,41 @@
+require './app/queries/active_scheduled_tweet'
+require './lib/services/fun_facts/fun_fact_tweeter'
+
+module TweetSchedule
+  # Tweets scheduled tweets for fun facts
+  class FunFactsScheduledTweeter
+    def self.tweet_all
+      new.tweet_all
+    end
+
+    def initialize(scheduled_tweets: ActiveScheduledTweet.all.fun_facts,
+                   fun_fact_tweeter: FunFacts::FunFactTweeter)
+      @scheduled_tweets = scheduled_tweets
+      @fun_fact_tweeter = fun_fact_tweeter
+    end
+
+    def tweet_all
+      @scheduled_tweets.each do |scheduled_tweet|
+        puts "Tweet fun fact about #{scheduled_tweet.album.name}"
+        begin
+          tweet = @fun_fact_tweeter.tweet_about(scheduled_tweet.album)
+          if tweet
+            scheduled_tweet.update(tweet_id: tweet.id)
+          else
+            Rollbar.warning(
+              'No fun fact available for ' \
+              "#{scheduled_tweet.album.artist.name} -" \
+              " #{scheduled_tweet.album.name}")
+            scheduled_tweet.update(tweet_id: -1)
+          end
+        rescue Exception => e
+          puts e.inspect
+          Rollbar.error(e, type: scheduled_tweet.type,
+                           album: scheduled_tweet.album.name,
+                           artist: scheduled_tweet.album.artist_name)
+          scheduled_tweet.update(tweet_id: -1)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -35,6 +35,16 @@ namespace :weekly_albums do
     end
   end
 
+
+  desc "Schedules fun facts from highlighted albums"
+  task schedule_fun_facts: :environment do
+    # if Date.current.wday == 1 # Only send on Monday
+      require './lib/services/tweet_schedule/tweet_scheduler'
+      TweetSchedule::TweetScheduler.new(albums: WeeklyAnniversaryQuery.all,
+                                        type: 'FunFacts').schedule_all
+    # end
+  end
+
   desc "Highlights top songs that have anniversary this week"
   task highlight_album_anniversaries: :environment do
     require './lib/services/tweet_schedule/top_song_scheduled_tweeter'
@@ -51,5 +61,11 @@ namespace :weekly_albums do
   task highlight_top_song_lyrics: :environment do
     require './lib/services/tweet_schedule/top_lyrics_scheduled_tweeter'
     TweetSchedule::TopLyricsScheduledTweeter.tweet_all
+  end
+
+  desc "Highlights album fun facts that have anniversary this week"
+  task highlight_fun_facts: :environment do
+    require './lib/services/tweet_schedule/fun_facts_scheduled_tweeter'
+    TweetSchedule::FunFactsScheduledTweeter.tweet_all
   end
 end

--- a/spec/lib/services/fun_facts/fun_fact_tweeter_spec.rb
+++ b/spec/lib/services/fun_facts/fun_fact_tweeter_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require './lib/services/top_song/song_tweeter'
+
+RSpec.describe FunFacts::FunFactTweeter do
+  describe '#tweet' do
+    let(:twitter_client) { WistfulIndie::Twitter::Client.client }
+    let(:artist) do
+      Artist.new(name: 'Animal Collective',
+                 twitter_screen_name: 'anmlcollective')
+    end
+    let(:album) { Album.new(artist: artist, name: 'Fall Be Kind', release_date: 7.years.ago, fun_fact: fun_fact) }
+    let(:fun_fact) { FunFact.new(description: '[twitter]\'s "What Would I Want? Sky" on [album] features the first ever licensed Grateful Dead sample') }
+
+    subject do
+      described_class.new(album: album, twitter_client: twitter_client)
+    end
+
+    it 'creates tweet about an album fun fact' do
+      expect(twitter_client).to receive(:update).with(
+        '@anmlcollective\'s "What Would I Want? Sky" on "Fall Be Kind" features the first ever licensed Grateful Dead sample'
+      )
+      subject.tweet
+    end
+
+    context 'with no fun fact' do
+      let(:fun_fact) { nil }
+
+      it 'doesn\'t tweet song' do
+        expect(twitter_client).not_to receive(:update)
+        subject.tweet
+      end
+    end
+  end
+end

--- a/spec/lib/services/tweet_schedule/fun_facts_scheduled_tweeter_spec.rb
+++ b/spec/lib/services/tweet_schedule/fun_facts_scheduled_tweeter_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require './lib/services/tweet_schedule/fun_facts_scheduled_tweeter'
+
+RSpec.describe TweetSchedule::FunFactsScheduledTweeter do
+  describe '#tweet_all' do
+    let(:artist) { double(Artist, name: 'Twin Peaks') }
+    let(:album) { double(Album, name: 'Sunken', artist: artist) }
+    let(:scheduled_tweet) do
+      double(ScheduledTweet, album: album).tap do |st|
+        allow(st).to receive(:update)
+      end
+    end
+    let(:tweet) { double('Tweet', id: 123456789) }
+    let(:fun_fact_tweeter) do
+      double('FunFactsTweeter').tap do |st|
+        allow(st).to receive(:tweet_about).and_return(tweet)
+      end
+    end
+
+    subject do
+      described_class.new(scheduled_tweets: [scheduled_tweet],
+                          fun_fact_tweeter: fun_fact_tweeter)
+    end
+
+    it 'tweets scheduled tweet' do
+      expect(fun_fact_tweeter)
+        .to receive(:tweet_about)
+        .with(scheduled_tweet.album)
+      subject.tweet_all
+    end
+
+    it 'marks scheduled tweet sent with tweet ID' do
+      expect(scheduled_tweet).to receive(:update).with(tweet_id: 123456789)
+      subject.tweet_all
+    end
+
+    context 'with tweet not sent' do
+      let(:fun_fact_tweeter) do
+        double('FunFactsTweeter').tap do |st|
+          allow(st).to receive(:tweet_about).and_return(nil)
+        end
+      end
+
+      it 'logs warning' do
+        expect(Rollbar).to receive(:warning).with(
+          'No fun fact available for ' \
+          "#{scheduled_tweet.album.artist.name} -" \
+          " #{scheduled_tweet.album.name}")
+          subject.tweet_all
+      end
+
+      it 'marks scheduld tweet failed with -1 in tweet ID' do
+        expect(scheduled_tweet).to receive(:update).with(tweet_id: -1)
+        subject.tweet_all
+      end
+    end
+  end
+end


### PR DESCRIPTION
Why
---
Fun facts are inherently fun, let's share them with everyone on twitter

This change addresses the need by
---------------------------------
Fun facts are scheduled alongside top songs, lyrics and album
anniversaries. They are then tweeted with the description